### PR TITLE
Deployment error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas
 plotly
 requests
-streamlit
+streamlit>=1.52.0


### PR DESCRIPTION
We don't have fixed versions in the requirements.txt. On Streamlit.io an old streamlit version (`streamlit==1.19.0`) will be installed, for some reason (see logs at #2 ). That old version has conflicts with newer versions of altair (which are not actively used in this project).
However: Requirering a newer version of streamlit solves the problem: Solves #2 

